### PR TITLE
fix up server in `index.js`, so as to not conflict with SimplePeer's default `/demo` routes served

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,16 +1,36 @@
-var fs = require('fs');
-var path = require('path');
-var SocketPeer = require('socketpeer');
-var url = require('url');
+const fs = require('fs');
+const http = require('http');
+const path = require('path');
+const url = require('url');
 
-var server = new SocketPeer();
+const SocketPeer = require('socketpeer');
 
-server.on('request', function (req, res) {
-  var stream;
-  var p = url.parse(req.url).pathname;
+const host = process.env.SOCKETPEER_HOST || process.env.HOST || '0.0.0.0';
+const port = process.env.SOCKETPEER_PORT || process.env.PORT || 3000;
+const nodeEnv = process.env.NODE_ENV || 'development';
+const httpServer = http.createServer();
+const peer = new SocketPeer({
+  httpServer: httpServer,
+  serveLibrary: true
+});
+
+httpServer.on('request', (req, res) => {
+  const p = url.parse(req.url).pathname;
   if (p === '/') {
     res.writeHead(200, {'Content-Type': 'text/html'});
-    stream = fs.createReadStream(path.join(__dirname, 'index.html'));
-    stream.pipe(res);
+    fs.createReadStream(path.join(__dirname, 'index.html')).pipe(res);
+  } else if (!p.startsWith('/socketpeer/')) {
+    res.writeHead(404, {'Content-Type': 'text/plain'});
+    res.end('File not found');
   }
 });
+
+if (!module.parent) {
+  httpServer.listen(port, host, () => {
+    console.log('[%s] Server listening on %s:%s', nodeEnv, host, port);
+  });
+}
+
+module.exports.httpServer = httpServer;
+
+module.exports.peer = peer;


### PR DESCRIPTION
let me know if there's a different way you think this should be handled

<hr>

FYI: I've been making some small recent adjustments to [`socketpeer`](https://github.com/cvan/socketpeer), so the ergonomics here can change soon; I'm open to suggestions.
