### PR TITLE
change license from "ISC" to "CC0-1.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "node index.js"
   },
   "author": "",
-  "license": "ISC",
+  "license": "CC0-1.0",
   "dependencies": {
     "socketpeer": "^1.0.1"
   }


### PR DESCRIPTION
or MIT or whichever license you choose. I just figured you had chosen `ISC` since it's the default when running `npm init`.